### PR TITLE
Update base image for tomcat to supported version Temurin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ If you are looking for a runnable docker image to test drive Hippo CMS you can u
 * [Gogreen docker image] - Community edition of Hippo gogreen demo website.
 
 ## Important notice:
+From Bloomreach Experience Manager 15, Java 8 isn't supported. Tagged version are in sync with Bloomreach versions
+
 The latest version of this image is no longer sets "-Xmx" JVM arguments by default. Instead, it supports "-XX:MaxRAMPercentage".
 
 To still set "-Xmx" and "-Xms" you need to set environmental variables MAX_HEAP and MIN_HEAP explicitly on the container.
@@ -76,9 +78,9 @@ e.g. if you set a maximum memory limit of 1024Mb then set MAX_RAM_PERCENTAGE to 
 **Step 2:** Add a docker file called Dockerfile in the root of the project with the following content
 
 ```dockerfile
-FROM openweb/hippo:mysql-13
+FROM openweb/hippo:mysql-15
 
-ADD target/<artifactId>-*-distribution.tar.gz /usr/local/tomcat
+ADD target/-artifactId-*-distribution.tar.gz /usr/local/tomcat
 ```
 
 **Step 3:** Add a docker ignore file called ".dockerignore" to the root of the project with the following content
@@ -175,7 +177,7 @@ services:
       - "8585:8080"
     restart: always
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7-debian
     volumes:
       - mysql_data:/var/lib/mysql
       #- ./dump:/docker-entrypoint-initdb.d

--- a/compose/docker-compose-without-named-volumes.yml
+++ b/compose/docker-compose-without-named-volumes.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   hippo:
-    image: openweb/hippo:mysql-10
+    image: openweb/hippo:mysql-15
     networks:
       - app_network
     environment:
@@ -16,7 +16,7 @@ services:
     ports:
       - "8765:8080"
   mysql:
-    image: mysql:5.5
+    image: mysql:5.7-debian
     environment:
       MYSQL_ROOT_PASSWORD: "rootPassword"
       MYSQL_DATABASE: "hippo"

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   hippo:
-    image: openweb/hippo:mysql-13
+    image: openweb/hippo:mysql-15
     networks:
       - app_network
     volumes:
@@ -20,7 +20,7 @@ services:
       - "8765:8080"
     restart: always
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7-debian
     volumes:
       - mysql_data:/var/lib/mysql
     environment:
@@ -39,7 +39,7 @@ volumes:
   hippo_repository:
     driver: local
   hippo_logs:
-    driver: local 
+    driver: local
 networks:
   app_network:
     driver: bridge

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
-#docker build --no-cache -f Dockerfile -t openweb/hippo:mysql-13 .
-FROM tomcat:9-jdk8-openjdk
-MAINTAINER Ebrahim Aharpour <ebrahim@openweb.nl>
+#docker build --no-cache -f Dockerfile -t openweb/hippo:mysql-15 .
+FROM tomcat:9-jdk11-temurin
+MAINTAINER Open Web IT B.V. <info@openweb.nl>
 
 ENV ENCODING=UTF-8 \
     CATALINA_HOME=/usr/local/tomcat \


### PR DESCRIPTION
Update of base image from openjdk to temurin
- compose examples updated to version with tag 15
- compose examples using linux based MySQL
- Readme mention dropped support for Java 8
- Maintainer set company e-mail